### PR TITLE
Update studyId type, use number instead of string

### DIFF
--- a/src/controller/survey/survey.controller.spec.ts
+++ b/src/controller/survey/survey.controller.spec.ts
@@ -4,7 +4,7 @@ import { SurveyService } from '../../service/survey.service';
 import { QuestionDto } from '../../module/survey/question.dto';
 import { Question } from '../../schemas/question.schemas';
 import { StudyIdDto } from '../../module/survey/studyId.dto';
-import { HttpException } from '@nestjs/common';
+import {ValidationPipe} from '@nestjs/common';
 
 const question: Question = {
   _id: "atcfwx",
@@ -25,7 +25,7 @@ const question: Question = {
     "NA you are not the asshole for asking, as long as you can graciously accept a “no, I don’t want to” as an answer. ",
     "NA - If you've asked and she said yes, don't feel bad. If you still feel guilty though, maybe offer to pay for her to get her hair done a different color?",
   ],
-  count: [0, 1, 0, 0, 0]
+  count: [0, 1, 0, 0, 0, 0]
 };
 
 const answer = {
@@ -49,6 +49,7 @@ const answer = {
 
 describe('SurveyController', () => {
   let controller: SurveyController;
+  let validationPipe: ValidationPipe;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -73,6 +74,7 @@ describe('SurveyController', () => {
     .compile();
 
     controller = module.get<SurveyController>(SurveyController);
+    validationPipe = new ValidationPipe({ transform: true, validateCustomDecorators: true });
   });
 
   it('should be defined', () => {
@@ -86,9 +88,14 @@ describe('SurveyController', () => {
       expect(actuall).toEqual(expectData);
     });
 
-    // invalid studyId
-    it ('should return error msg "studyId should be a number"', async () => {
-      await expect(controller.getQuestion({ studyId:6 })).rejects.toThrow(HttpException);
+    it('should throw BadRequestException for studyId 6', async () => {
+      await expect(validationPipe.transform({ studyId: 6 }, { type: 'query', metatype: StudyIdDto }))
+          .rejects.toThrow('Bad Request Exception');
+    });
+
+    it('should throw BadRequestException for studyId 0', async () => {
+      await expect(validationPipe.transform({ studyId: 0 }, { type: 'query', metatype: StudyIdDto }))
+          .rejects.toThrow('Bad Request Exception');
     });
   });
 

--- a/src/controller/survey/survey.controller.ts
+++ b/src/controller/survey/survey.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Logger, Post, Query } from '@nestjs/common';
+import {Body, Controller, Get, HttpException, HttpStatus, Logger, Post, Query, ValidationPipe} from '@nestjs/common';
 import { ApiBadRequestResponse, ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { StudyIdDto } from '../../module/survey/studyId.dto';
 import { AnswersDto } from '../../module/survey/answers.dto';
@@ -24,6 +24,8 @@ export class SurveyController {
          *   studyId
          * }
          */
+
+        // console.log('Validated studyId:', studyId);
 
         return await this.surveyService.findQuestion(studyId).then((question) => {
             return question;

--- a/src/controller/survey/survey.controller.ts
+++ b/src/controller/survey/survey.controller.ts
@@ -1,4 +1,4 @@
-import {Body, Controller, Get, HttpException, HttpStatus, Logger, Post, Query, ValidationPipe} from '@nestjs/common';
+import {Body, Controller, Get, HttpException, HttpStatus, Logger, Post, Query} from '@nestjs/common';
 import { ApiBadRequestResponse, ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { StudyIdDto } from '../../module/survey/studyId.dto';
 import { AnswersDto } from '../../module/survey/answers.dto';

--- a/src/module/survey/studyId.dto.ts
+++ b/src/module/survey/studyId.dto.ts
@@ -1,5 +1,5 @@
 // more usage, refer to https://github.com/typestack/class-validator?tab=readme-ov-file#usage
-import {IsIn, IsInt, IsNotEmpty} from 'class-validator';
+import {IsIn, IsNotEmpty} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import {Type} from "class-transformer";
 

--- a/src/module/survey/studyId.dto.ts
+++ b/src/module/survey/studyId.dto.ts
@@ -1,6 +1,7 @@
 // more usage, refer to https://github.com/typestack/class-validator?tab=readme-ov-file#usage
-import { IsNotEmpty} from 'class-validator';
+import {IsIn, IsInt, IsNotEmpty} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import {Type} from "class-transformer";
 
 export class StudyIdDto {
 
@@ -11,8 +12,11 @@ export class StudyIdDto {
     @ApiProperty({
         description: 'The study id',
         required: true,
-        // enum: [1, 2, 3, 4]
+        // enum: [1, 2, 3, 4, 5]
     })
+    @Type(() => Number)
     @IsNotEmpty()
+    @IsIn([1, 2, 3, 4, 5], { message: 'studyId must be one of the following values: 1, 2, 3, 4, 5' })
     studyId: number;
+
 }

--- a/src/schemas/question.schemas.ts
+++ b/src/schemas/question.schemas.ts
@@ -77,7 +77,7 @@ export class Question {
     required: true,
     type: [Number]
   })
-  count: number[];
+  count: { [key: number]: number }
 }
 
 export const QuestionSchema = SchemaFactory.createForClass(Question);

--- a/src/service/survey.service.spec.ts
+++ b/src/service/survey.service.spec.ts
@@ -23,7 +23,7 @@ const question: Question = {
     "NA you are not the asshole for asking, as long as you can graciously accept a “no, I don’t want to” as an answer. ",
     "NA - If you've asked and she said yes, don't feel bad. If you still feel guilty though, maybe offer to pay for her to get her hair done a different color?",
   ],
-  count: [0, 1, 0, 0, 0]
+  count: [0, 1, 0, 0, 0, 0]
 };
 
 const answer = {

--- a/src/service/survey.service.ts
+++ b/src/service/survey.service.ts
@@ -15,7 +15,7 @@ export class SurveyService {
 
     async findQuestion(studyId: StudyIdDto): Promise<Question> {
         const question = await this.questionModel.findOne().sort({ [`count.${studyId.studyId}`]:1 }).exec();
-        question.count[studyId.studyId] += 1;
+        question.count[studyId.studyId] = (question.count[studyId.studyId] || 0) + 1;
         await question.save();
         return question;
     }


### PR DESCRIPTION
1. Use IsIn and Type decorator in studyId
2. For invalid input, directly response bad request instead of throwing httpException in test files
![image](https://github.com/user-attachments/assets/99739f12-ce76-4cc7-b590-eaa4ab80a714)
