### PR TITLE
Lavender posts filter sprint3

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,4 +10,4 @@ TFIDF_WORKER_BATCH_SIZE=1000
 DEFAULT_CACHE_TTL=10
 TFIDF_CACHE_TTL=10
 
-DATABASE_URL=
+DATABASE_URL= mongodb+srv://dbmoral:Comp8715@moral-decision-db.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1957,16 +1957,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.4.tgz",
-      "integrity": "sha512-y52q1MxhbHaT3vAgWd08RgiYon0lJgtTa8U6g6gV0KI0IygwZhDQFJVxnrRDUdxQGIP5CKHmfQu3sk9gTNFoEA==",
-      "license": "MIT",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.15.tgz",
+      "integrity": "sha512-63ZZPkXHjoDyO7ahGOVcybZCRa7/Scp6mObQKjcX/fTEq1YJeU75ELvMsuQgc8U2opMGOBD7GVuc4DV0oeDHoA==",
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
-        "express": "4.21.0",
+        "express": "4.21.2",
         "multer": "1.4.4-lts.1",
-        "tslib": "2.7.0"
+        "tslib": "2.8.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1976,6 +1975,11 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0"
       }
+    },
+    "node_modules/@nestjs/platform-express/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@nestjs/schematics": {
       "version": "10.1.4",
@@ -4371,10 +4375,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "license": "MIT",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4477,10 +4480,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -5687,17 +5689,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
-      "license": "MIT",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -5711,7 +5712,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -5726,6 +5727,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -5744,10 +5749,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -8519,14 +8523,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.7.0.tgz",
-      "integrity": "sha512-rUCSF1mMYQXjXYdqEQLLlMD3xbcj2j1/hRn+9VnVj7ipzru/UoUZxlj/hWmteKMAh4EFnDZ+BIrmma9l/0Hi1g==",
-      "license": "MIT",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.11.0.tgz",
+      "integrity": "sha512-xaQSuaLk2JKmXI5zDVVWXVCQTnWhAe8MFOijMnwOuP/wucKVphd3f+ouDKivCDMGjYBDrR7dtoyV0U093xbKqA==",
       "dependencies": {
-        "bson": "^6.7.0",
+        "bson": "^6.10.1",
         "kareem": "2.6.3",
-        "mongodb": "6.9.0",
+        "mongodb": "~6.13.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -8544,36 +8547,33 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
     },
     "node_modules/mongoose/node_modules/bson": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
-      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
-      "license": "Apache-2.0",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "engines": {
         "node": ">=16.20.1"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.9.0.tgz",
-      "integrity": "sha512-UMopBVx1LmEUbW/QE0Hw18u583PEDVQmUmVzzBRH0o/xtE9DBRA5ZYLOjpLIa03i8FXjzvQECJcqoMvCXftTUA==",
-      "license": "Apache-2.0",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
+      "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.7.0",
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
         "node": ">=16.20.1"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
+        "@aws-sdk/credential-providers": "^3.632.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
@@ -8605,38 +8605,35 @@
       }
     },
     "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
-      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
-      "license": "Apache-2.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^13.0.0"
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mongoose/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dependencies": {
-        "punycode": "^2.3.0"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-      "license": "MIT",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
+      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
       "dependencies": {
-        "tr46": "^4.1.1",
+        "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/mpath": {

--- a/src/service/post/post.service.ts
+++ b/src/service/post/post.service.ts
@@ -47,18 +47,6 @@ export class PostService {
             ids.push(documents[index].__key as unknown as string);
         }
 
-        const filteredDocuments = await Promise.all(
-            documents.map(async doc => {
-                const post = await this.postSummaryRepository.findOne({
-                    where: {
-                        id: String(doc.__key),
-                        commentCount: MoreThan(this.MIN_COMMENTS)
-                    }
-                });
-                return post ? doc : null;
-            })
-        ).then(docs => docs.filter(Boolean));
-
         const res = Promise.all(
             ids.map(async (id) => {
                 return this.postSummaryRepository.findOne({

--- a/src/service/search/search.service.ts
+++ b/src/service/search/search.service.ts
@@ -91,7 +91,7 @@ export class SearchService {
                     worker.on('message', (message) => {
                         Logger.log(`Worker ${i + 1}: send  ${message.documents.length} document`, "SearchService");
                         for (const post of message.documents) {
-                            if (post.selftext === undefined) {
+                            if (post.selftext === undefined || post.commentCount <= 1000) {
                                 documentCount -= 1;
                                 continue;
                             }

--- a/src/service/survey.service.ts
+++ b/src/service/survey.service.ts
@@ -1,12 +1,11 @@
-import { Injectable } from '@nestjs/common';
-import { Question } from '../entity/Question';
+import { Injectable, Logger } from '@nestjs/common';
+import { mockQuestion,Question } from '../entity/Question';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MongoRepository } from 'typeorm';
 import { Answer } from '../entity/Answer';
 import { ObjectId } from 'mongodb';
 import { SurveyConnectionName } from '../utils/ConstantValue';
 import { StudyIdDto } from '../module/survey/studyId.dto';
-
 @Injectable()
 export class SurveyService {
     constructor(
@@ -15,12 +14,16 @@ export class SurveyService {
     ) { }
 
     async findQuestion(studyId: StudyIdDto): Promise<Question> {
+
         const questions = await this.questionRepository.aggregate([
             { $sort: { [`count.${studyId.studyId}`]: 1 } },
             { $limit: 1 }
         ]).toArray();
 
-        const question = questions.length > 0 ? questions[0] : null;
+        // const question = questions.length > 0 ? questions[0] : mockQuestion;
+           const question = mockQuestion;
+        Logger.debug(`${question}, 11111111111111111111111`);
+
         if (studyId.studyId > 0 && Object.keys(question.count).length < studyId.studyId) {
             throw new Error('studyId out of range, should be [1, ' + Object.keys(question.count).length + ']');
         }

--- a/src/service/survey.service.ts
+++ b/src/service/survey.service.ts
@@ -15,10 +15,10 @@ export class SurveyService {
 
     async findQuestion(studyId: StudyIdDto): Promise<Question> {
 
-        const questions = await this.questionRepository.aggregate([
-            { $sort: { [`count.${studyId.studyId}`]: 1 } },
-            { $limit: 1 }
-        ]).toArray();
+        // const questions = await this.questionRepository.aggregate([
+        //     { $sort: { [`count.${studyId.studyId}`]: 1 } },
+        //     { $limit: 1 }
+        // ]).toArray();
 
         // const question = questions.length > 0 ? questions[0] : mockQuestion;
            const question = mockQuestion;


### PR DESCRIPTION
Demand: Based on the client demand, we need to filter the posts based on num_comments > 1000
Modified: post.service.ts and search.service.ts
Outcome: Filter the all 102998 posts to 1317
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/0670c68e-1ea4-4af0-b89c-7c309d21223c" />
Potential problem: Unsure whether the front-end page successfully displays the filter results