### PR TITLE
Sprint 3 Filter Function

### DIFF
--- a/src/service/post/post.service.ts
+++ b/src/service/post/post.service.ts
@@ -3,10 +3,11 @@ import { PostConnectionName } from '../../utils/ConstantValue';
 import { PostSummary } from '../../entity/PostSummary';
 import { SearchService } from '../search/search.service';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
 
 @Injectable()
 export class PostService {
+    private readonly MIN_COMMENTS = 1000;
     constructor(
         @InjectRepository(PostSummary, PostConnectionName) private postSummaryRepository: Repository<PostSummary>,
         private searchService: SearchService,
@@ -28,6 +29,9 @@ export class PostService {
 
     async getPostsOrderedByComments(pageSize: number = 10, page: number = 0): Promise<PostSummary[]> {
         return this.postSummaryRepository.find({
+            where: {
+                commentCount: MoreThan(this.MIN_COMMENTS)
+            },
             order: {
                 commentCount: "DESC"
             },

--- a/src/service/search/search.service.ts
+++ b/src/service/search/search.service.ts
@@ -91,7 +91,7 @@ export class SearchService {
                     worker.on('message', (message) => {
                         Logger.log(`Worker ${i + 1}: send  ${message.documents.length} document`, "SearchService");
                         for (const post of message.documents) {
-                            if (post.selftext === undefined) {
+                            if (post.selftext === undefined || post.commentCount <= 1000) {
                                 documentCount -= 1;
                                 continue;
                             }


### PR DESCRIPTION
Demand: Based on the client demand, we need to filter the posts based on num_comments > 1000
Modified: post.service.ts and search.service.ts
Outcome: Filter the all 102998 posts to 1317
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/ec991fc4-5677-4d8a-9114-291983784048" />

Potential problem: Unsure whether the front-end page successfully displays the filter results